### PR TITLE
Add custom weight tag command and NBT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Command and Permissions
     /weight add <item> <weight value>
     Permission: weight.add
     Description: add item to the weight files. The item will be on Misc Items Weight file on Additional Items section.
+    /weight custom add <weight value>
+    Permission: weight.custom
+    Description: add a custom weight tag to the item you're holding.
     Permission: weight.notify
     Description: Players with this permission will be notified when an item isn't on the weight files.
     You can use permission mode to calculate the weight of players. You need to add these 3 permissions. weight.level1.x, weight.level2.x, weight.level3.x . Where x is your amount of weight in the level.

--- a/src/main/java/ted_2001/WeightRPG/Commands/Tabcompleter.java
+++ b/src/main/java/ted_2001/WeightRPG/Commands/Tabcompleter.java
@@ -32,6 +32,8 @@ public class Tabcompleter implements TabCompleter {
                     results.add("set");
                 if(sender.hasPermission("weight.add"))
                     results.add("add");
+                if(sender.hasPermission("weight.custom"))
+                    results.add("custom");
                 if (sender.hasPermission("weight.help"))
                     results.add("help");
 
@@ -55,6 +57,11 @@ public class Tabcompleter implements TabCompleter {
 
                     // Return the sorted tab-completion results based on the user's input argument.
                     return sortedResults(args[1]);
+                    }
+                } else if(arg0.equalsIgnoreCase("custom")) {
+                    if(sender.hasPermission("weight.custom")) {
+                        results.add("add");
+                        return sortedResults(args[1]);
                     }
                 }
             }

--- a/src/main/java/ted_2001/WeightRPG/Commands/WeightCommands.java
+++ b/src/main/java/ted_2001/WeightRPG/Commands/WeightCommands.java
@@ -5,6 +5,10 @@ import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.command.*;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -148,6 +152,14 @@ public class WeightCommands implements CommandExecutor {
                     } else
                         // Player does not have permission to execute the add command. Send him a no permission message.
                         noPermMessage(p);
+                } else if(arg0.equalsIgnoreCase("custom")){
+                    // The first argument is "custom".
+                    // Check if the player has the "weight.custom" permission to execute the custom command.
+                    if (p.hasPermission("weight.custom")) {
+                        String customMessage = w.formatMessage(Messages.getMessages().getString("custom-add-command-message", getPlugin().getPluginPrefix() + "&aYou can add a custom weight to the item in your hand using &e/weight custom add <value>."), p);
+                        p.sendMessage(ColorUtils.translateColorCodes(customMessage));
+                    } else
+                        noPermMessage(p);
                 } else if (arg0.equalsIgnoreCase("help")) {
                     // The first argument is "help".
                     // Check if the player has the "weight.help" permission to execute the help command.
@@ -214,6 +226,15 @@ public class WeightCommands implements CommandExecutor {
                         p.sendMessage(ColorUtils.translateColorCodes(addMessage));
                     } else
                         noPermMessage(p);
+                }else if(arg0.equalsIgnoreCase("custom")){
+                    if(p.hasPermission("weight.custom")) {
+                        if(arg1.equalsIgnoreCase("ADD")) {
+                            String customMessage = w.formatMessage(Messages.getMessages().getString("custom-add-command-message", getPlugin().getPluginPrefix() + "&aYou can add a custom weight to the item in your hand using &e/weight custom add <value>."), p);
+                            p.sendMessage(ColorUtils.translateColorCodes(customMessage));
+                        } else
+                            unknownCommandMessage(p);
+                    } else
+                        noPermMessage(p);
                 }else
                     // The first argument is none of the recognized commands.
                     unknownCommandMessage(p);
@@ -226,6 +247,7 @@ public class WeightCommands implements CommandExecutor {
                 String weightCommand = args[0];
                 String itemName = args[1].toUpperCase();
                 String weightValue = args[2];
+                String arg1Raw = args[1];
 
                 // Command: /weight set <item> <value>
                 if(weightCommand.equalsIgnoreCase("set")){
@@ -388,6 +410,33 @@ public class WeightCommands implements CommandExecutor {
                         return false;
 
                     }else
+                        noPermMessage(p);
+                }else if(weightCommand.equalsIgnoreCase("custom")) {
+                    if(p.hasPermission("weight.custom")) {
+                        if(arg1Raw.equalsIgnoreCase("add")) {
+                            float customValue;
+                            try {
+                                customValue = Float.parseFloat(weightValue);
+                            } catch (NumberFormatException ex) {
+                                p.sendMessage(ColorUtils.translateColorCodes(getPlugin().getPluginPrefix() + "&cInvalid number."));
+                                return false;
+                            }
+                            ItemStack item = p.getInventory().getItemInMainHand();
+                            if(item != null && item.getType() != Material.AIR) {
+                                ItemMeta meta = item.getItemMeta();
+                                NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+                                meta.getPersistentDataContainer().set(key, PersistentDataType.FLOAT, customValue);
+                                item.setItemMeta(meta);
+                                String msg = w.formatMessage(Messages.getMessages().getString("custom-add-item-success-message", getPlugin().getPluginPrefix() + "&aSet custom weight &e" + weightValue + " &afor item."), p);
+                                msg = msg.replaceAll("%itemweight%", weightValue);
+                                p.sendMessage(ColorUtils.translateColorCodes(msg));
+                            } else {
+                                String msg = w.formatMessage(Messages.getMessages().getString("custom-add-item-fail-message", getPlugin().getPluginPrefix() + "&cYou must hold an item to set its weight."), p);
+                                p.sendMessage(ColorUtils.translateColorCodes(msg));
+                            }
+                        } else
+                            unknownCommandMessage(p);
+                    } else
                         noPermMessage(p);
                 }else
                     unknownCommandMessage(p);

--- a/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
+++ b/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
@@ -20,6 +20,9 @@ import org.bukkit.event.player.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import ted_2001.WeightRPG.Utils.CalculateWeight;
 import ted_2001.WeightRPG.Utils.ColorUtils;
 import ted_2001.WeightRPG.Utils.Messages;
@@ -179,18 +182,24 @@ public class WeightCalculateListeners implements Listener {
             boolean isCustomItem = false;
             ItemMeta itemMeta = item.getItemMeta();
 
-            // Check if the item is a custom-named item with weight defined in the config file.
-            if (itemMeta != null && customItemsWeight.containsKey(itemMeta.getDisplayName())) {
-                weight = customItemsWeight.get(itemMeta.getDisplayName());
-                isCustomItem = true;
-            } else if(itemMeta != null && boostItemsWeight.containsKey(itemMeta.getDisplayName())){
-                boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
-                if(boostWeight != 0)
-                    boostWeight +=  (boostItemsWeight.get(itemMeta.getDisplayName()) * amount);
-                playerBoostWeight.put(p.getUniqueId(), boostWeight);
-                weight = 0.0f;
-            }else if (globalItemsWeight.get(item.getType()) != null) 
-                weight = globalItemsWeight.get(item.getType());
+            if (itemMeta != null) {
+                NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+                PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+                if (pdc.has(key, PersistentDataType.FLOAT)) {
+                    weight = pdc.get(key, PersistentDataType.FLOAT);
+                    isCustomItem = true;
+                } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                    weight = customItemsWeight.get(itemMeta.getDisplayName());
+                    isCustomItem = true;
+                } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                    boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                    if (boostWeight != 0)
+                        boostWeight += (boostItemsWeight.get(itemMeta.getDisplayName()) * amount);
+                    playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                    weight = 0.0f;
+                } else if (globalItemsWeight.get(item.getType()) != null)
+                    weight = globalItemsWeight.get(item.getType());
+            }
             
             // Check if the player's weight is not being tracked yet or if the item is a custom item.
             if (playerWeight.get(p.getUniqueId()) == 0 || playerWeight.get(p.getUniqueId()) == null || isCustomItem) {
@@ -279,18 +288,24 @@ public class WeightCalculateListeners implements Listener {
         boolean isCustomItem = false;
         ItemMeta itemMeta = item.getItemMeta();
 
-        // Check if the item is a custom-named item with weight defined in the config file.
-        if (itemMeta != null && customItemsWeight.containsKey(itemMeta.getDisplayName())) {
-            weight = customItemsWeight.get(itemMeta.getDisplayName());
-            isCustomItem = true;
-        } else if(itemMeta != null && boostItemsWeight.containsKey(itemMeta.getDisplayName())){
-            boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
-            if(boostWeight != 0)
-                boostWeight -= (boostItemsWeight.get(itemMeta.getDisplayName()) * amount);
-            playerBoostWeight.put(p.getUniqueId(), boostWeight);
-            weight = 0.0f;
-        }else if(globalItemsWeight.get(item.getType()) != null)
-            weight = globalItemsWeight.get(item.getType());
+        if (itemMeta != null) {
+            NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+            PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+            if (pdc.has(key, PersistentDataType.FLOAT)) {
+                weight = pdc.get(key, PersistentDataType.FLOAT);
+                isCustomItem = true;
+            } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                weight = customItemsWeight.get(itemMeta.getDisplayName());
+                isCustomItem = true;
+            } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                if (boostWeight != 0)
+                    boostWeight -= (boostItemsWeight.get(itemMeta.getDisplayName()) * amount);
+                playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                weight = 0.0f;
+            } else if (globalItemsWeight.get(item.getType()) != null)
+                weight = globalItemsWeight.get(item.getType());
+        }
 
         // Handle weight calculation and weight effects for the player based on the dropped item.
         if (playerWeight.get(p.getUniqueId()) == 0 || playerWeight.get(p.getUniqueId()) == null || isCustomItem) {
@@ -341,18 +356,24 @@ public class WeightCalculateListeners implements Listener {
         boolean isCustomItem = false;
         ItemMeta itemMeta = block.getItemMeta();
 
-        // Check if the item is a custom-named item with weight defined in the config file.
-        if (itemMeta != null && customItemsWeight.containsKey(itemMeta.getDisplayName())) {
-            weight = customItemsWeight.get(itemMeta.getDisplayName());
-            isCustomItem = true;
-        } else if(itemMeta != null && boostItemsWeight.containsKey(itemMeta.getDisplayName())){
-            boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
-            if(boostWeight != 0)
-                boostWeight -= boostItemsWeight.get(itemMeta.getDisplayName());
-            playerBoostWeight.put(p.getUniqueId(), boostWeight);
-            weight = 0.0f;
-        }else if(globalItemsWeight.get(block.getType()) != null)
-            weight = globalItemsWeight.get(block.getType());
+        if (itemMeta != null) {
+            NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+            PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+            if (pdc.has(key, PersistentDataType.FLOAT)) {
+                weight = pdc.get(key, PersistentDataType.FLOAT);
+                isCustomItem = true;
+            } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                weight = customItemsWeight.get(itemMeta.getDisplayName());
+                isCustomItem = true;
+            } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                if (boostWeight != 0)
+                    boostWeight -= boostItemsWeight.get(itemMeta.getDisplayName());
+                playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                weight = 0.0f;
+            } else if (globalItemsWeight.get(block.getType()) != null)
+                weight = globalItemsWeight.get(block.getType());
+        }
 
         // Handle weight calculation and weight effects for the player based on the placed block.
         if (playerWeight.get(p.getUniqueId()) == 0 || playerWeight.get(p.getUniqueId()) == null || isCustomItem) {

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -32,6 +32,7 @@ weight-command-spectator-message: "%pluginprefix% &4Weight-RPG is disabled for &
 get-command-message: "%pluginprefix% &aYou can see items weight by using the command &e/weight get <item>."
 set-command-message: "%pluginprefix% &aYou can set the weight value of an item using the command &e/weight set <item> <value>."
 add-command-message: "%pluginprefix% &a&aYou can add an item on the weight files using the command &e/weight add <item> <value>. &aYou will find the record on the Misc Items Weight file under Additional Items section."
+custom-add-command-message: "%pluginprefix% &aYou can add a custom weight to the item in your hand using the command &e/weight custom add <value>."
 
 # These messages are sent to the player when he types a correct (succes message) item or not (fail message).
 # Here you can use %item% for the typed item and %itemweight% (this one only for the success message) for its weight.
@@ -43,6 +44,8 @@ set-item-fail-message: "%pluginprefix% &cCouldn't find &e%item% &cin the weight 
 
 add-item-success-message: "%pluginprefix% &aYou successfully added &e%item% &ato the weight files with a weight value of &b%itemweight%&a."
 add-item-found-message: "%pluginprefix% &cThis item already exists in the weight files and it's weight value is &b%itemweight%&c."
+custom-add-item-success-message: "%pluginprefix% &aYou set the custom weight of this item to &b%itemweight%&a."
+custom-add-item-fail-message: "%pluginprefix% &cYou must hold an item to set a custom weight."
 
 no-permission-message: "%pluginprefix% &cYou don't have permission to use this command."
 unknown-command: "%pluginprefix% &cCouldn't find this command."
@@ -66,5 +69,6 @@ help-command-message:
   - "&a/weight get <item> &6show the item's weight."
   - "&a/weight set <item> <weight> &6set the item's weight."
   - "&a/weight add <item> <weight> &6add an item to the weight files."
+  - "&a/weight custom add <weight> &6add a custom weight tag to the item in your hand."
   - "&a/weight reload &6reload all files and apply changes to server."
   - "&5----------------> &eWeight-RPG Commands&5 <----------------"


### PR DESCRIPTION
## Summary
- read weight values from item NBT tags
- add `/weight custom add <value>` command to set item weight tag
- document and tab-complete new custom command

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891b5524f54832397a67dd266e99748