### PR TITLE
Add custom weight tag command and NBT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Features
     You can disable the plugin in certain worlds.
     Players can have a cooldown for dropping items. This is to prevent players from throwing items to have maximum speed. You can disable this feature and modify the cooldown in seconds in the config file.
     You can view item's weight using /weight get <item> command.
+    Optionally append the weight value to item lore via the config.
     WorldGuard support. You can use the 'weight-rpg' flag to deny using the plugin in certain regions. (WorldGuard version 7.0 or later).
     PlaceholderAPI support. you can use all these placeholders in any plugin that supports PlaceholderAPI (2.10.0 version or above).
 
@@ -65,6 +66,9 @@ Command and Permissions
     /weight add <item> <weight value>
     Permission: weight.add
     Description: add item to the weight files. The item will be on Misc Items Weight file on Additional Items section.
+    /weight custom add <weight value>
+    Permission: weight.custom
+    Description: add a custom weight tag to the item you're holding.
     Permission: weight.notify
     Description: Players with this permission will be notified when an item isn't on the weight files.
     You can use permission mode to calculate the weight of players. You need to add these 3 permissions. weight.level1.x, weight.level2.x, weight.level3.x . Where x is your amount of weight in the level.

--- a/src/main/java/ted_2001/WeightRPG/Commands/Tabcompleter.java
+++ b/src/main/java/ted_2001/WeightRPG/Commands/Tabcompleter.java
@@ -32,6 +32,8 @@ public class Tabcompleter implements TabCompleter {
                     results.add("set");
                 if(sender.hasPermission("weight.add"))
                     results.add("add");
+                if(sender.hasPermission("weight.custom"))
+                    results.add("custom");
                 if (sender.hasPermission("weight.help"))
                     results.add("help");
 
@@ -55,6 +57,11 @@ public class Tabcompleter implements TabCompleter {
 
                     // Return the sorted tab-completion results based on the user's input argument.
                     return sortedResults(args[1]);
+                    }
+                } else if(arg0.equalsIgnoreCase("custom")) {
+                    if(sender.hasPermission("weight.custom")) {
+                        results.add("add");
+                        return sortedResults(args[1]);
                     }
                 }
             }

--- a/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
+++ b/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
@@ -20,6 +20,9 @@ import org.bukkit.event.player.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import ted_2001.WeightRPG.Utils.CalculateWeight;
 import ted_2001.WeightRPG.Utils.ColorUtils;
 import ted_2001.WeightRPG.Utils.Messages;
@@ -179,18 +182,24 @@ public class WeightCalculateListeners implements Listener {
             boolean isCustomItem = false;
             ItemMeta itemMeta = item.getItemMeta();
 
-            // Check if the item is a custom-named item with weight defined in the config file.
-            if (itemMeta != null && customItemsWeight.containsKey(itemMeta.getDisplayName())) {
-                weight = customItemsWeight.get(itemMeta.getDisplayName());
-                isCustomItem = true;
-            } else if(itemMeta != null && boostItemsWeight.containsKey(itemMeta.getDisplayName())){
-                boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
-                if(boostWeight != 0)
-                    boostWeight +=  (boostItemsWeight.get(itemMeta.getDisplayName()) * amount);
-                playerBoostWeight.put(p.getUniqueId(), boostWeight);
-                weight = 0.0f;
-            }else if (globalItemsWeight.get(item.getType()) != null) 
-                weight = globalItemsWeight.get(item.getType());
+            if (itemMeta != null) {
+                NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+                PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+                if (pdc.has(key, PersistentDataType.FLOAT)) {
+                    weight = pdc.get(key, PersistentDataType.FLOAT);
+                    isCustomItem = true;
+                } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                    weight = customItemsWeight.get(itemMeta.getDisplayName());
+                    isCustomItem = true;
+                } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                    boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                    if (boostWeight != 0)
+                        boostWeight += (boostItemsWeight.get(itemMeta.getDisplayName()) * amount);
+                    playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                    weight = 0.0f;
+                } else if (globalItemsWeight.get(item.getType()) != null)
+                    weight = globalItemsWeight.get(item.getType());
+            }
             
             // Check if the player's weight is not being tracked yet or if the item is a custom item.
             if (playerWeight.get(p.getUniqueId()) == 0 || playerWeight.get(p.getUniqueId()) == null || isCustomItem) {
@@ -279,18 +288,24 @@ public class WeightCalculateListeners implements Listener {
         boolean isCustomItem = false;
         ItemMeta itemMeta = item.getItemMeta();
 
-        // Check if the item is a custom-named item with weight defined in the config file.
-        if (itemMeta != null && customItemsWeight.containsKey(itemMeta.getDisplayName())) {
-            weight = customItemsWeight.get(itemMeta.getDisplayName());
-            isCustomItem = true;
-        } else if(itemMeta != null && boostItemsWeight.containsKey(itemMeta.getDisplayName())){
-            boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
-            if(boostWeight != 0)
-                boostWeight -= (boostItemsWeight.get(itemMeta.getDisplayName()) * amount);
-            playerBoostWeight.put(p.getUniqueId(), boostWeight);
-            weight = 0.0f;
-        }else if(globalItemsWeight.get(item.getType()) != null)
-            weight = globalItemsWeight.get(item.getType());
+        if (itemMeta != null) {
+            NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+            PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+            if (pdc.has(key, PersistentDataType.FLOAT)) {
+                weight = pdc.get(key, PersistentDataType.FLOAT);
+                isCustomItem = true;
+            } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                weight = customItemsWeight.get(itemMeta.getDisplayName());
+                isCustomItem = true;
+            } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                if (boostWeight != 0)
+                    boostWeight -= (boostItemsWeight.get(itemMeta.getDisplayName()) * amount);
+                playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                weight = 0.0f;
+            } else if (globalItemsWeight.get(item.getType()) != null)
+                weight = globalItemsWeight.get(item.getType());
+        }
 
         // Handle weight calculation and weight effects for the player based on the dropped item.
         if (playerWeight.get(p.getUniqueId()) == 0 || playerWeight.get(p.getUniqueId()) == null || isCustomItem) {
@@ -341,18 +356,24 @@ public class WeightCalculateListeners implements Listener {
         boolean isCustomItem = false;
         ItemMeta itemMeta = block.getItemMeta();
 
-        // Check if the item is a custom-named item with weight defined in the config file.
-        if (itemMeta != null && customItemsWeight.containsKey(itemMeta.getDisplayName())) {
-            weight = customItemsWeight.get(itemMeta.getDisplayName());
-            isCustomItem = true;
-        } else if(itemMeta != null && boostItemsWeight.containsKey(itemMeta.getDisplayName())){
-            boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
-            if(boostWeight != 0)
-                boostWeight -= boostItemsWeight.get(itemMeta.getDisplayName());
-            playerBoostWeight.put(p.getUniqueId(), boostWeight);
-            weight = 0.0f;
-        }else if(globalItemsWeight.get(block.getType()) != null)
-            weight = globalItemsWeight.get(block.getType());
+        if (itemMeta != null) {
+            NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+            PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+            if (pdc.has(key, PersistentDataType.FLOAT)) {
+                weight = pdc.get(key, PersistentDataType.FLOAT);
+                isCustomItem = true;
+            } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                weight = customItemsWeight.get(itemMeta.getDisplayName());
+                isCustomItem = true;
+            } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
+                boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                if (boostWeight != 0)
+                    boostWeight -= boostItemsWeight.get(itemMeta.getDisplayName());
+                playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                weight = 0.0f;
+            } else if (globalItemsWeight.get(block.getType()) != null)
+                weight = globalItemsWeight.get(block.getType());
+        }
 
         // Handle weight calculation and weight effects for the player based on the placed block.
         if (playerWeight.get(p.getUniqueId()) == 0 || playerWeight.get(p.getUniqueId()) == null || isCustomItem) {

--- a/src/main/java/ted_2001/WeightRPG/Utils/CalculateWeight.java
+++ b/src/main/java/ted_2001/WeightRPG/Utils/CalculateWeight.java
@@ -10,9 +10,13 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import ted_2001.WeightRPG.Utils.WorldGuard.WorldGuardRegion;
 
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -120,25 +124,80 @@ public class CalculateWeight {
         ItemMeta itemMeta = itemStack.getItemMeta();
 
         if (itemMeta != null) {
-            String displayName = itemMeta.getDisplayName();
-            // Check if the item has a custom weight based on its display name from config file
-            if (customItemsWeight.containsKey(displayName))
-                itemWeight = customItemsWeight.get(displayName);
+            // Check for custom weight stored in the item's persistent data container
+            NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+            PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+            if (pdc.has(key, PersistentDataType.FLOAT)) {
+                itemWeight = pdc.get(key, PersistentDataType.FLOAT);
+            } else {
+                String displayName = itemMeta.getDisplayName();
+                // Check if the item has a custom weight based on its display name from config file
+                if (customItemsWeight.containsKey(displayName))
+                    itemWeight = customItemsWeight.get(displayName);
 
-            // Check if the item is a boost item weight based on its display name from config file
-            else if (boostItemsWeight.containsKey(displayName)) {
-                // Boost items don't add weight to the player.
-                float boostWeight = boostItemsWeight.get(displayName) * itemStack.getAmount();
-                float currentBoostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
-                playerBoostWeight.put(p.getUniqueId(), currentBoostWeight + boostWeight);
-                return 0.0f;
+                // Check if the item is a boost item weight based on its display name from config file
+                else if (boostItemsWeight.containsKey(displayName)) {
+                    // Boost items don't add weight to the player.
+                    float boostWeight = boostItemsWeight.get(displayName) * itemStack.getAmount();
+                    float currentBoostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                    playerBoostWeight.put(p.getUniqueId(), currentBoostWeight + boostWeight);
+                    return 0.0f;
+                }
+                    // Check if the item has a global weight based on its material type
+                else if (globalItemsWeight.containsKey(itemStack.getType()))
+                    itemWeight = globalItemsWeight.get(itemStack.getType());
             }
-                // Check if the item has a global weight based on its material type
-            else if (globalItemsWeight.containsKey(itemStack.getType()))
-                itemWeight = globalItemsWeight.get(itemStack.getType());
         }
 
+        updateItemWeightLore(itemStack, itemWeight);
+
         return itemWeight * itemStack.getAmount();
+    }
+
+    /**
+     * Adds or removes the weight line in the item's lore depending on the configuration.
+     *
+     * @param itemStack the item to update
+     * @param weight    the weight value assigned to the item
+     */
+    public static void updateItemWeightLore(ItemStack itemStack, float weight) {
+        if (itemStack == null) return;
+        if (getPlugin().getConfig().getBoolean("item-weight-lore.enabled") && weight > 0f) {
+            addWeightLore(itemStack, weight);
+        } else {
+            removeWeightLore(itemStack);
+        }
+    }
+
+    private static void addWeightLore(ItemStack itemStack, float weight) {
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null) return;
+
+        String template = getPlugin().getConfig().getString("item-weight-lore.format", "&7Weight: &e%weight%");
+        String line = template.replace("%weight%", String.format("%.2f", weight));
+        String coloredLine = ColorUtils.translateColorCodes(line);
+
+        List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+        String prefix = ChatColor.stripColor(ColorUtils.translateColorCodes(template.split("%weight%")[0]));
+        lore.removeIf(l -> ChatColor.stripColor(l).startsWith(prefix));
+        lore.add(coloredLine);
+        meta.setLore(lore);
+        itemStack.setItemMeta(meta);
+    }
+
+    public static void removeWeightLore(ItemStack itemStack) {
+        if (itemStack == null) return;
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null || !meta.hasLore()) return;
+
+        String template = getPlugin().getConfig().getString("item-weight-lore.format", "&7Weight: &e%weight%");
+        String prefix = ChatColor.stripColor(ColorUtils.translateColorCodes(template.split("%weight%")[0]));
+        List<String> lore = new ArrayList<>(meta.getLore());
+        boolean removed = lore.removeIf(l -> ChatColor.stripColor(l).startsWith(prefix));
+        if (removed) {
+            meta.setLore(lore.isEmpty() ? null : lore);
+            itemStack.setItemMeta(meta);
+        }
     }
 
     public void applyWeightEffects(Player p) {

--- a/src/main/java/ted_2001/WeightRPG/WeightRPG.java
+++ b/src/main/java/ted_2001/WeightRPG/WeightRPG.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.inventory.ItemStack;
 import ted_2001.WeightRPG.Commands.Tabcompleter;
 import ted_2001.WeightRPG.Commands.WeightCommands;
 import ted_2001.WeightRPG.Listeners.WeightCalculateListeners;
@@ -126,6 +127,15 @@ public final class WeightRPG extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        if (getConfig().getBoolean("item-weight-lore.enabled")) {
+            for (Player player : getServer().getOnlinePlayers()) {
+                ItemStack[] storage = player.getInventory().getStorageContents();
+                for (ItemStack item : storage) CalculateWeight.removeWeightLore(item);
+                for (ItemStack item : player.getInventory().getExtraContents()) CalculateWeight.removeWeightLore(item);
+                for (ItemStack item : player.getInventory().getArmorContents()) CalculateWeight.removeWeightLore(item);
+                CalculateWeight.removeWeightLore(player.getInventory().getItemInOffHand());
+            }
+        }
         saveDefaultConfig();
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -108,6 +108,12 @@ boost-items:
   - "&aSuper Backpack=50"
   - "&#1cebee&lEnhanced Bag=100"
 
+# Add the item's weight value to its lore.
+# Players can disable this feature here if they do not want the lore modified.
+item-weight-lore:
+  enabled: false
+  format: "&7Weight: &e%weight%"
+
 plugin-prefix: "&7[&eWeight-RPG&7]&f: "
 
 # Notify all the players that have the weight.notify permission that an item isn't in the weight files.

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -32,6 +32,7 @@ weight-command-spectator-message: "%pluginprefix% &4Weight-RPG is disabled for &
 get-command-message: "%pluginprefix% &aYou can see items weight by using the command &e/weight get <item>."
 set-command-message: "%pluginprefix% &aYou can set the weight value of an item using the command &e/weight set <item> <value>."
 add-command-message: "%pluginprefix% &a&aYou can add an item on the weight files using the command &e/weight add <item> <value>. &aYou will find the record on the Misc Items Weight file under Additional Items section."
+custom-add-command-message: "%pluginprefix% &aYou can add a custom weight to the item in your hand using the command &e/weight custom add <value>."
 
 # These messages are sent to the player when he types a correct (succes message) item or not (fail message).
 # Here you can use %item% for the typed item and %itemweight% (this one only for the success message) for its weight.
@@ -43,6 +44,8 @@ set-item-fail-message: "%pluginprefix% &cCouldn't find &e%item% &cin the weight 
 
 add-item-success-message: "%pluginprefix% &aYou successfully added &e%item% &ato the weight files with a weight value of &b%itemweight%&a."
 add-item-found-message: "%pluginprefix% &cThis item already exists in the weight files and it's weight value is &b%itemweight%&c."
+custom-add-item-success-message: "%pluginprefix% &aYou set the custom weight of this item to &b%itemweight%&a."
+custom-add-item-fail-message: "%pluginprefix% &cYou must hold an item to set a custom weight."
 
 no-permission-message: "%pluginprefix% &cYou don't have permission to use this command."
 unknown-command: "%pluginprefix% &cCouldn't find this command."
@@ -66,5 +69,6 @@ help-command-message:
   - "&a/weight get <item> &6show the item's weight."
   - "&a/weight set <item> <weight> &6set the item's weight."
   - "&a/weight add <item> <weight> &6add an item to the weight files."
+  - "&a/weight custom add <weight> &6add a custom weight tag to the item in your hand."
   - "&a/weight reload &6reload all files and apply changes to server."
   - "&5----------------> &eWeight-RPG Commands&5 <----------------"


### PR DESCRIPTION
## Summary
- read weight values from item NBT tags
- add `/weight custom add <value>` command to set item weight tag
- optionally append item weight to lore via new `item-weight-lore` config, with cleanup on disable
- document and tab-complete new custom command