### PR TITLE
Add boost weight NBT command and refine lore handling

### DIFF
--- a/src/main/java/ted_2001/WeightRPG/Commands/Tabcompleter.java
+++ b/src/main/java/ted_2001/WeightRPG/Commands/Tabcompleter.java
@@ -34,6 +34,8 @@ public class Tabcompleter implements TabCompleter {
                     results.add("add");
                 if(sender.hasPermission("weight.custom"))
                     results.add("custom");
+                if(sender.hasPermission("weight.boost"))
+                    results.add("boost");
                 if (sender.hasPermission("weight.help"))
                     results.add("help");
 
@@ -60,6 +62,11 @@ public class Tabcompleter implements TabCompleter {
                     }
                 } else if(arg0.equalsIgnoreCase("custom")) {
                     if(sender.hasPermission("weight.custom")) {
+                        results.add("add");
+                        return sortedResults(args[1]);
+                    }
+                } else if(arg0.equalsIgnoreCase("boost")) {
+                    if(sender.hasPermission("weight.boost")) {
                         results.add("add");
                         return sortedResults(args[1]);
                     }

--- a/src/main/java/ted_2001/WeightRPG/Commands/WeightCommands.java
+++ b/src/main/java/ted_2001/WeightRPG/Commands/WeightCommands.java
@@ -157,6 +157,14 @@ public class WeightCommands implements CommandExecutor {
                         p.sendMessage(ColorUtils.translateColorCodes(customMessage));
                     } else
                         noPermMessage(p);
+                } else if(arg0.equalsIgnoreCase("boost")) {
+                    // The first argument is "boost".
+                    // Check if the player has the "weight.boost" permission to execute the boost command.
+                    if (p.hasPermission("weight.boost")) {
+                        String boostMessage = w.formatMessage(Messages.getMessages().getString("boost-add-command-message", getPlugin().getPluginPrefix() + "&aYou can add a boost weight to the item in your hand using &e/weight boost add <value>."), p);
+                        p.sendMessage(ColorUtils.translateColorCodes(boostMessage));
+                    } else
+                        noPermMessage(p);
                 } else if (arg0.equalsIgnoreCase("help")) {
                     // The first argument is "help".
                     // Check if the player has the "weight.help" permission to execute the help command.
@@ -228,6 +236,15 @@ public class WeightCommands implements CommandExecutor {
                         if(arg1.equalsIgnoreCase("ADD")) {
                             String customMessage = w.formatMessage(Messages.getMessages().getString("custom-add-command-message", getPlugin().getPluginPrefix() + "&aYou can add a custom weight to the item in your hand using &e/weight custom add <value>."), p);
                             p.sendMessage(ColorUtils.translateColorCodes(customMessage));
+                        } else
+                            unknownCommandMessage(p);
+                    } else
+                        noPermMessage(p);
+                } else if(arg0.equalsIgnoreCase("boost")) {
+                    if(p.hasPermission("weight.boost")) {
+                        if(arg1.equals("ADD")) {
+                            String boostMessage = w.formatMessage(Messages.getMessages().getString("boost-add-command-message", getPlugin().getPluginPrefix() + "&aYou can add a boost weight to the item in your hand using &e/weight boost add <value>."), p);
+                            p.sendMessage(ColorUtils.translateColorCodes(boostMessage));
                         } else
                             unknownCommandMessage(p);
                     } else
@@ -429,6 +446,34 @@ public class WeightCommands implements CommandExecutor {
                                 p.sendMessage(ColorUtils.translateColorCodes(msg));
                             } else {
                                 String msg = w.formatMessage(Messages.getMessages().getString("custom-add-item-fail-message", getPlugin().getPluginPrefix() + "&cYou must hold an item to set its weight."), p);
+                                p.sendMessage(ColorUtils.translateColorCodes(msg));
+                            }
+                        } else
+                            unknownCommandMessage(p);
+                    } else
+                        noPermMessage(p);
+                } else if(weightCommand.equalsIgnoreCase("boost")) {
+                    if(p.hasPermission("weight.boost")) {
+                        if(arg1Raw.equalsIgnoreCase("add")) {
+                            float boostValue;
+                            try {
+                                boostValue = Float.parseFloat(weightValue);
+                            } catch (NumberFormatException ex) {
+                                p.sendMessage(ColorUtils.translateColorCodes(getPlugin().getPluginPrefix() + "&cInvalid number."));
+                                return false;
+                            }
+                            ItemStack item = p.getInventory().getItemInMainHand();
+                            if(item != null && item.getType() != Material.AIR) {
+                                ItemMeta meta = item.getItemMeta();
+                                NamespacedKey key = new NamespacedKey(getPlugin(), "boost");
+                                meta.getPersistentDataContainer().set(key, PersistentDataType.FLOAT, boostValue);
+                                item.setItemMeta(meta);
+                                ItemLoreUtils.updateBoostItemLore(item, boostValue);
+                                String msg = w.formatMessage(Messages.getMessages().getString("boost-add-item-success-message", getPlugin().getPluginPrefix() + "&aSet boost weight &e" + weightValue + " &afor item."), p);
+                                msg = msg.replaceAll("%boostweight%", weightValue);
+                                p.sendMessage(ColorUtils.translateColorCodes(msg));
+                            } else {
+                                String msg = w.formatMessage(Messages.getMessages().getString("boost-add-item-fail-message", getPlugin().getPluginPrefix() + "&cYou must hold an item to set its boost weight."), p);
                                 p.sendMessage(ColorUtils.translateColorCodes(msg));
                             }
                         } else

--- a/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
+++ b/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
@@ -186,10 +186,17 @@ public class WeightCalculateListeners implements Listener {
 
             if (itemMeta != null) {
                 NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+                NamespacedKey boostKey = new NamespacedKey(getPlugin(), "boost");
                 PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
                 if (pdc.has(key, PersistentDataType.FLOAT)) {
                     weight = pdc.get(key, PersistentDataType.FLOAT);
                     isCustomItem = true;
+                } else if (pdc.has(boostKey, PersistentDataType.FLOAT)) {
+                    boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                    if (boostWeight != 0)
+                        boostWeight += (pdc.get(boostKey, PersistentDataType.FLOAT) * amount);
+                    playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                    weight = 0.0f;
                 } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
                     weight = customItemsWeight.get(itemMeta.getDisplayName());
                     isCustomItem = true;
@@ -292,10 +299,17 @@ public class WeightCalculateListeners implements Listener {
 
         if (itemMeta != null) {
             NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+            NamespacedKey boostKey = new NamespacedKey(getPlugin(), "boost");
             PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
             if (pdc.has(key, PersistentDataType.FLOAT)) {
                 weight = pdc.get(key, PersistentDataType.FLOAT);
                 isCustomItem = true;
+            } else if (pdc.has(boostKey, PersistentDataType.FLOAT)) {
+                boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                if (boostWeight != 0)
+                    boostWeight -= (pdc.get(boostKey, PersistentDataType.FLOAT) * amount);
+                playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                weight = 0.0f;
             } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
                 weight = customItemsWeight.get(itemMeta.getDisplayName());
                 isCustomItem = true;
@@ -360,10 +374,17 @@ public class WeightCalculateListeners implements Listener {
 
         if (itemMeta != null) {
             NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+            NamespacedKey boostKey = new NamespacedKey(getPlugin(), "boost");
             PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
             if (pdc.has(key, PersistentDataType.FLOAT)) {
                 weight = pdc.get(key, PersistentDataType.FLOAT);
                 isCustomItem = true;
+            } else if (pdc.has(boostKey, PersistentDataType.FLOAT)) {
+                boostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                if (boostWeight != 0)
+                    boostWeight -= pdc.get(boostKey, PersistentDataType.FLOAT);
+                playerBoostWeight.put(p.getUniqueId(), boostWeight);
+                weight = 0.0f;
             } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
                 weight = customItemsWeight.get(itemMeta.getDisplayName());
                 isCustomItem = true;

--- a/src/main/java/ted_2001/WeightRPG/Utils/CalculateWeight.java
+++ b/src/main/java/ted_2001/WeightRPG/Utils/CalculateWeight.java
@@ -123,11 +123,19 @@ public class CalculateWeight {
         ItemMeta itemMeta = itemStack.getItemMeta();
 
         if (itemMeta != null) {
-            // Check for custom weight stored in the item's persistent data container
+            // Check for custom or boost weight stored in the item's persistent data container
             NamespacedKey key = new NamespacedKey(getPlugin(), "weight");
+            NamespacedKey boostKey = new NamespacedKey(getPlugin(), "boost");
             PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
             if (pdc.has(key, PersistentDataType.FLOAT)) {
                 itemWeight = pdc.get(key, PersistentDataType.FLOAT);
+            } else if (pdc.has(boostKey, PersistentDataType.FLOAT)) {
+                float boostPerItem = pdc.get(boostKey, PersistentDataType.FLOAT);
+                ItemLoreUtils.updateBoostItemLore(itemStack, boostPerItem);
+                float boostWeight = boostPerItem * itemStack.getAmount();
+                float currentBoostWeight = playerBoostWeight.getOrDefault(p.getUniqueId(), 0f);
+                playerBoostWeight.put(p.getUniqueId(), currentBoostWeight + boostWeight);
+                return 0.0f;
             } else {
                 String displayName = itemMeta.getDisplayName();
                 // Check if the item has a custom weight based on its display name from config file

--- a/src/main/java/ted_2001/WeightRPG/Utils/ItemLoreUtils.java
+++ b/src/main/java/ted_2001/WeightRPG/Utils/ItemLoreUtils.java
@@ -49,13 +49,21 @@ public final class ItemLoreUtils {
             return;
 
         NamespacedKey loreKey = new NamespacedKey(getPlugin(), "weightLore");
+        NamespacedKey blankKey = new NamespacedKey(getPlugin(), "weightLoreBlank");
         PersistentDataContainer pdc = meta.getPersistentDataContainer();
         List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
 
         String previousLine = pdc.get(loreKey, PersistentDataType.STRING);
+        Byte hadBlank = pdc.get(blankKey, PersistentDataType.BYTE);
         if (previousLine != null) {
-            lore.removeIf(line -> line.equals(previousLine));
+            int index = lore.indexOf(previousLine);
+            if (index != -1) {
+                lore.remove(index);
+                if (hadBlank != null && hadBlank == 1 && index - 1 >= 0 && lore.get(index - 1).isEmpty())
+                    lore.remove(index - 1);
+            }
             pdc.remove(loreKey);
+            pdc.remove(blankKey);
         }
 
         if (getPlugin().getConfig().getBoolean("item-weight-lore.enabled") && weight > 0f) {
@@ -68,6 +76,14 @@ public final class ItemLoreUtils {
                     .replace("%item%", itemName);
 
             line = ChatColor.translateAlternateColorCodes('&', line);
+
+            boolean hasTrailingBlank = !lore.isEmpty() && lore.get(lore.size() - 1).isEmpty();
+            if (!hasTrailingBlank) {
+                lore.add("");
+                pdc.set(blankKey, PersistentDataType.BYTE, (byte) 1);
+            } else
+                pdc.set(blankKey, PersistentDataType.BYTE, (byte) 0);
+
             lore.add(line);
             pdc.set(loreKey, PersistentDataType.STRING, line);
         }
@@ -93,13 +109,21 @@ public final class ItemLoreUtils {
             return;
 
         NamespacedKey loreKey = new NamespacedKey(getPlugin(), "weightLore");
+        NamespacedKey blankKey = new NamespacedKey(getPlugin(), "weightLoreBlank");
         PersistentDataContainer pdc = meta.getPersistentDataContainer();
         List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
 
         String previousLine = pdc.get(loreKey, PersistentDataType.STRING);
+        Byte hadBlank = pdc.get(blankKey, PersistentDataType.BYTE);
         if (previousLine != null) {
-            lore.removeIf(line -> line.equals(previousLine));
+            int index = lore.indexOf(previousLine);
+            if (index != -1) {
+                lore.remove(index);
+                if (hadBlank != null && hadBlank == 1 && index - 1 >= 0 && lore.get(index - 1).isEmpty())
+                    lore.remove(index - 1);
+            }
             pdc.remove(loreKey);
+            pdc.remove(blankKey);
         }
 
         if (getPlugin().getConfig().getBoolean("item-weight-lore.enabled") && boostWeight > 0f) {
@@ -112,6 +136,14 @@ public final class ItemLoreUtils {
                     .replace("%item%", itemName);
 
             line = ChatColor.translateAlternateColorCodes('&', line);
+
+            boolean hasTrailingBlank = !lore.isEmpty() && lore.get(lore.size() - 1).isEmpty();
+            if (!hasTrailingBlank) {
+                lore.add("");
+                pdc.set(blankKey, PersistentDataType.BYTE, (byte) 1);
+            } else
+                pdc.set(blankKey, PersistentDataType.BYTE, (byte) 0);
+
             lore.add(line);
             pdc.set(loreKey, PersistentDataType.STRING, line);
         }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -33,6 +33,7 @@ get-command-message: "%pluginprefix% &aYou can see items weight by using the com
 set-command-message: "%pluginprefix% &aYou can set the weight value of an item using the command &e/weight set <item> <value>."
 add-command-message: "%pluginprefix% &a&aYou can add an item on the weight files using the command &e/weight add <item> <value>. &aYou will find the record on the Misc Items Weight file under Additional Items section."
 custom-add-command-message: "%pluginprefix% &aYou can add a custom weight to the item in your hand using the command &e/weight custom add <value>."
+boost-add-command-message: "%pluginprefix% &aYou can add a boost weight to the item in your hand using the command &e/weight boost add <value>."
 
 # These messages are sent to the player when he types a correct (succes message) item or not (fail message).
 # Here you can use %item% for the typed item and %itemweight% (this one only for the success message) for its weight.
@@ -46,6 +47,8 @@ add-item-success-message: "%pluginprefix% &aYou successfully added &e%item% &ato
 add-item-found-message: "%pluginprefix% &cThis item already exists in the weight files and it's weight value is &b%itemweight%&c."
 custom-add-item-success-message: "%pluginprefix% &aYou set the custom weight of this item to &b%itemweight%&a."
 custom-add-item-fail-message: "%pluginprefix% &cYou must hold an item to set a custom weight."
+boost-add-item-success-message: "%pluginprefix% &aYou set the boost weight of this item to &b%boostweight%&a."
+boost-add-item-fail-message: "%pluginprefix% &cYou must hold an item to set a boost weight."
 
 no-permission-message: "%pluginprefix% &cYou don't have permission to use this command."
 unknown-command: "%pluginprefix% &cCouldn't find this command."
@@ -70,5 +73,6 @@ help-command-message:
   - "&a/weight set <item> <weight> &6set the item's weight."
   - "&a/weight add <item> <weight> &6add an item to the weight files."
   - "&a/weight custom add <weight> &6add a custom weight tag to the item in your hand."
+  - "&a/weight boost add <weight> &6add a boost weight tag to the item in your hand."
   - "&a/weight reload &6reload all files and apply changes to server."
   - "&5----------------> &eWeight-RPG Commands&5 <----------------"


### PR DESCRIPTION
## Summary
- add `/weight boost add <value>` to tag held items with boost weight via NBT
- append plugin weight lore last with a protected blank line
- handle boost NBT in calculations, listeners, tab completion, and messages
