### PR TITLE
Fix boost item lore refresh on reload

### DIFF
--- a/src/main/java/ted_2001/WeightRPG/Commands/WeightCommands.java
+++ b/src/main/java/ted_2001/WeightRPG/Commands/WeightCommands.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static ted_2001.WeightRPG.Utils.JsonFile.customItemsWeight;
 import static ted_2001.WeightRPG.Utils.JsonFile.globalItemsWeight;
+import static ted_2001.WeightRPG.Utils.JsonFile.boostItemsWeight;
 import static ted_2001.WeightRPG.WeightRPG.getPlugin;
 import static ted_2001.WeightRPG.Utils.CalculateWeight.weightThresholdValues;
 
@@ -566,6 +567,7 @@ public class WeightCommands implements CommandExecutor {
         // Clear the stored custom and global item weights.
         customItemsWeight.clear();
         globalItemsWeight.clear();
+        boostItemsWeight.clear();
 
         // If the config file exists, reload it. Otherwise, create a new one with default values.
         if(config.exists())

--- a/src/main/java/ted_2001/WeightRPG/Utils/ItemLoreUtils.java
+++ b/src/main/java/ted_2001/WeightRPG/Utils/ItemLoreUtils.java
@@ -120,10 +120,23 @@ public final class ItemLoreUtils {
         String previousLine = pdc.get(loreKey, PersistentDataType.STRING);
         Byte hadBlank = pdc.get(blankKey, PersistentDataType.BYTE);
         boolean enabled = getPlugin().getConfig().getBoolean("item-weight-lore.enabled");
-        if (previousLine != null) {
-            if (enabled && boostWeight > 0f)
-                return;
 
+        String line = null;
+        if (enabled && boostWeight > 0f) {
+            String template = Objects.requireNonNull(getPlugin().getConfig().getString(
+                    "item-weight-lore.boost-message", "&7%item% Weight Boost: &e%boost%"));
+
+            String itemName = meta.hasDisplayName() ? meta.getDisplayName() : formatMaterialName(item.getType().name());
+            line = template
+                    .replace("%boost%", String.format("%.2f", boostWeight))
+                    .replace("%item%", itemName);
+
+            line = ChatColor.translateAlternateColorCodes('&', line);
+            if (line.equals(previousLine))
+                return;
+        }
+
+        if (previousLine != null) {
             int index = lore.indexOf(previousLine);
             if (index != -1) {
                 lore.remove(index);
@@ -134,17 +147,7 @@ public final class ItemLoreUtils {
             pdc.remove(blankKey);
         }
 
-        if (enabled && boostWeight > 0f) {
-            String template = Objects.requireNonNull(getPlugin().getConfig().getString(
-                    "item-weight-lore.boost-message", "&7%item% Weight Boost: &e%boost%"));
-
-            String itemName = meta.hasDisplayName() ? meta.getDisplayName() : formatMaterialName(item.getType().name());
-            String line = template
-                    .replace("%boost%", String.format("%.2f", boostWeight))
-                    .replace("%item%", itemName);
-
-            line = ChatColor.translateAlternateColorCodes('&', line);
-
+        if (line != null) {
             boolean hasTrailingBlank = !lore.isEmpty() && lore.get(lore.size() - 1).isEmpty();
             if (!hasTrailingBlank) {
                 lore.add("");


### PR DESCRIPTION
## Summary
- Refresh boost item lore when recalculating weight and avoid duplicating lines
- Reset boost item weight map on reload to apply config changes