### PR TITLE
Fix boost item lore not updating on reload

### DIFF
--- a/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
+++ b/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
@@ -190,6 +190,7 @@ public class WeightCalculateListeners implements Listener {
                 if (pdc.has(key, PersistentDataType.FLOAT)) {
                     weight = pdc.get(key, PersistentDataType.FLOAT);
                     ItemLoreUtils.updateItemLore(item, weight);
+                    ItemLoreUtils.updateBoostItemLore(item, 0f);
                     isCustomItem = true;
                 } else if (pdc.has(boostKey, PersistentDataType.FLOAT)) {
                     float boostPerItem = pdc.get(boostKey, PersistentDataType.FLOAT);
@@ -199,6 +200,7 @@ public class WeightCalculateListeners implements Listener {
                 } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
                     weight = customItemsWeight.get(itemMeta.getDisplayName());
                     ItemLoreUtils.updateItemLore(item, weight);
+                    ItemLoreUtils.updateBoostItemLore(item, 0f);
                     isCustomItem = true;
                 } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
                     float boostPerItem = boostItemsWeight.get(itemMeta.getDisplayName());
@@ -208,6 +210,11 @@ public class WeightCalculateListeners implements Listener {
                 } else if (globalItemsWeight.get(item.getType()) != null) {
                     weight = globalItemsWeight.get(item.getType());
                     ItemLoreUtils.updateItemLore(item, weight);
+                    ItemLoreUtils.updateBoostItemLore(item, 0f);
+                } else {
+                    // Item is not weighted or boosted anymore - remove any leftover lore
+                    ItemLoreUtils.updateBoostItemLore(item, 0f);
+                    ItemLoreUtils.updateItemLore(item, 0f);
                 }
             }
 

--- a/src/main/java/ted_2001/WeightRPG/Utils/CalculateWeight.java
+++ b/src/main/java/ted_2001/WeightRPG/Utils/CalculateWeight.java
@@ -139,8 +139,9 @@ public class CalculateWeight {
             } else {
                 String displayName = itemMeta.getDisplayName();
                 // Check if the item has a custom weight based on its display name from config file
-                if (customItemsWeight.containsKey(displayName))
+                if (customItemsWeight.containsKey(displayName)) {
                     itemWeight = customItemsWeight.get(displayName);
+                }
 
                 // Check if the item is a boost item weight based on its display name from config file
                 else if (boostItemsWeight.containsKey(displayName)) {
@@ -151,9 +152,14 @@ public class CalculateWeight {
                     playerBoostWeight.put(p.getUniqueId(), currentBoostWeight + boostWeight);
                     return 0.0f;
                 }
-                    // Check if the item has a global weight based on its material type
-                else if (globalItemsWeight.containsKey(itemStack.getType()))
+
+                // Check if the item has a global weight based on its material type
+                else if (globalItemsWeight.containsKey(itemStack.getType())) {
                     itemWeight = globalItemsWeight.get(itemStack.getType());
+                }
+
+                // Ensure outdated boost lore is removed for items that are no longer boost items
+                ItemLoreUtils.updateBoostItemLore(itemStack, 0f);
             }
         }
 


### PR DESCRIPTION
## Summary
- Remove stale boost lore when items are no longer configured as boost items, ensuring lore refreshes once after reload
- Clear old boost lore in pickup listener for items with custom or global weights

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68931fa1fd208323b4c9ee07e3a1972b