### PR TITLE
Fix item stacking and lore duplication

### DIFF
--- a/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
+++ b/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
@@ -188,17 +188,21 @@ public class WeightCalculateListeners implements Listener {
                 PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
                 if (pdc.has(key, PersistentDataType.FLOAT)) {
                     weight = pdc.get(key, PersistentDataType.FLOAT);
+                    ItemLoreUtils.updateItemLore(item, weight);
                 } else if (pdc.has(boostKey, PersistentDataType.FLOAT)) {
-                    // Boost items have no weight themselves
-                    weight = 0.0f;
+                    float boostPerItem = pdc.get(boostKey, PersistentDataType.FLOAT);
+                    ItemLoreUtils.updateBoostItemLore(item, boostPerItem);
                 } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
                     weight = customItemsWeight.get(itemMeta.getDisplayName());
+                    ItemLoreUtils.updateItemLore(item, weight);
                 } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
-                    // Items providing weight boost
-                    weight = 0.0f;
+                    float boostPerItem = boostItemsWeight.get(itemMeta.getDisplayName());
+                    ItemLoreUtils.updateBoostItemLore(item, boostPerItem);
                 } else if (globalItemsWeight.get(item.getType()) != null) {
                     weight = globalItemsWeight.get(item.getType());
+                    ItemLoreUtils.updateItemLore(item, weight);
                 }
+                e.getItem().setItemStack(item);
             }
 
             // Notify the player and update their weight/lore after the item has stacked in the inventory.

--- a/src/main/java/ted_2001/WeightRPG/Utils/ItemLoreUtils.java
+++ b/src/main/java/ted_2001/WeightRPG/Utils/ItemLoreUtils.java
@@ -68,12 +68,20 @@ public final class ItemLoreUtils {
                     .replace("%item%", itemName);
 
             line = ChatColor.translateAlternateColorCodes('&', line);
-            if (line.equals(previousLine))
+            String plainLine = ChatColor.stripColor(line);
+            if (previousLine != null && plainLine.equals(ChatColor.stripColor(previousLine)))
                 return; // Lore already up-to-date
         }
 
         if (previousLine != null) {
-            int index = lore.indexOf(previousLine);
+            String plainPrev = ChatColor.stripColor(previousLine);
+            int index = -1;
+            for (int i = 0; i < lore.size(); i++) {
+                if (ChatColor.stripColor(lore.get(i)).equals(plainPrev)) {
+                    index = i;
+                    break;
+                }
+            }
             if (index != -1) {
                 lore.remove(index);
                 if (hadBlank != null && hadBlank == 1 && index - 1 >= 0 && lore.get(index - 1).isEmpty())
@@ -92,7 +100,7 @@ public final class ItemLoreUtils {
                 pdc.set(blankKey, PersistentDataType.BYTE, (byte) 0);
 
             lore.add(line);
-            pdc.set(loreKey, PersistentDataType.STRING, line);
+            pdc.set(loreKey, PersistentDataType.STRING, ChatColor.stripColor(line));
         }
 
         meta.setLore(lore.isEmpty() ? null : lore);
@@ -139,12 +147,20 @@ public final class ItemLoreUtils {
                     .replace("%item%", itemName);
 
             line = ChatColor.translateAlternateColorCodes('&', line);
-            if (line.equals(previousLine))
+            String plainLine = ChatColor.stripColor(line);
+            if (previousLine != null && plainLine.equals(ChatColor.stripColor(previousLine)))
                 return;
         }
 
         if (previousLine != null) {
-            int index = lore.indexOf(previousLine);
+            String plainPrev = ChatColor.stripColor(previousLine);
+            int index = -1;
+            for (int i = 0; i < lore.size(); i++) {
+                if (ChatColor.stripColor(lore.get(i)).equals(plainPrev)) {
+                    index = i;
+                    break;
+                }
+            }
             if (index != -1) {
                 lore.remove(index);
                 if (hadBlank != null && hadBlank == 1 && index - 1 >= 0 && lore.get(index - 1).isEmpty())
@@ -163,7 +179,7 @@ public final class ItemLoreUtils {
                 pdc.set(blankKey, PersistentDataType.BYTE, (byte) 0);
 
             lore.add(line);
-            pdc.set(loreKey, PersistentDataType.STRING, line);
+            pdc.set(loreKey, PersistentDataType.STRING, ChatColor.stripColor(line));
         }
 
         meta.setLore(lore.isEmpty() ? null : lore);


### PR DESCRIPTION
## Summary
- ensure picked-up items have weight/boost lore before stacking so inventory merges correctly
- store color-stripped lore markers to avoid repeating weight lines on colored items
