### PR TITLE
Fix item stacking and lore duplication

### DIFF
--- a/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
+++ b/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
@@ -188,17 +188,21 @@ public class WeightCalculateListeners implements Listener {
                 PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
                 if (pdc.has(key, PersistentDataType.FLOAT)) {
                     weight = pdc.get(key, PersistentDataType.FLOAT);
+                    ItemLoreUtils.updateItemLore(item, weight);
                 } else if (pdc.has(boostKey, PersistentDataType.FLOAT)) {
-                    // Boost items have no weight themselves
-                    weight = 0.0f;
+                    float boostPerItem = pdc.get(boostKey, PersistentDataType.FLOAT);
+                    ItemLoreUtils.updateBoostItemLore(item, boostPerItem);
                 } else if (customItemsWeight.containsKey(itemMeta.getDisplayName())) {
                     weight = customItemsWeight.get(itemMeta.getDisplayName());
+                    ItemLoreUtils.updateItemLore(item, weight);
                 } else if (boostItemsWeight.containsKey(itemMeta.getDisplayName())) {
-                    // Items providing weight boost
-                    weight = 0.0f;
+                    float boostPerItem = boostItemsWeight.get(itemMeta.getDisplayName());
+                    ItemLoreUtils.updateBoostItemLore(item, boostPerItem);
                 } else if (globalItemsWeight.get(item.getType()) != null) {
                     weight = globalItemsWeight.get(item.getType());
+                    ItemLoreUtils.updateItemLore(item, weight);
                 }
+                e.getItem().setItemStack(item);
             }
 
             // Notify the player and update their weight/lore after the item has stacked in the inventory.


### PR DESCRIPTION
## Summary
- refine lore update logic to remove trailing blank markers so items stack correctly
- strip colors and use lore prefix detection to prevent repeated weight/boost lines