### PR TITLE
Add Custom Model Data weights and boosts

### DIFF
--- a/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
+++ b/src/main/java/ted_2001/WeightRPG/Listeners/WeightCalculateListeners.java
@@ -89,9 +89,7 @@ public class WeightCalculateListeners implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerChangedWorldEvent(PlayerChangedWorldEvent event) {
-        Player player = event.getPlayer();
-        // calculateWeight performs enabled-world/gamemode and WorldGuard checks itself.
-        weightCalculation.calculateWeight(player);
+        weightCalculation.calculateWeight(event.getPlayer());
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -170,7 +168,6 @@ public class WeightCalculateListeners implements Listener {
             return;
         }
 
-        // Preserve custom name/PDC metadata from the actual consumed item.
         ItemStack block = event.getItemInHand().clone();
         block.setAmount(1);
         if (block.getType() == Material.FIRE) {
@@ -198,7 +195,7 @@ public class WeightCalculateListeners implements Listener {
         if (Double.compare(from.getX(), to.getX()) == 0
                 && Double.compare(from.getY(), to.getY()) == 0
                 && Double.compare(from.getZ(), to.getZ()) == 0) {
-            return; // yaw/pitch-only movement
+            return;
         }
 
         Player player = event.getPlayer();
@@ -212,7 +209,6 @@ public class WeightCalculateListeners implements Listener {
             return;
         }
 
-        // Weight is maintained by inventory events + scheduler. Do not rescan the whole inventory per move packet.
         if (to.getY() <= from.getY()) {
             return;
         }
@@ -330,6 +326,15 @@ public class WeightCalculateListeners implements Listener {
                     subtractBoost(player, pdcBoost * item.getAmount());
                 }
                 return new ResolvedItemWeight(true, 0f, true, pdcBoost);
+            }
+
+            CalculateWeight.ModelDataMatch modelData = CalculateWeight.resolveCustomModelData(item);
+            if (modelData.matched()) {
+                if (modelData.boostPerItem() != 0f && adjustBoost) {
+                    subtractBoost(player, modelData.boostPerItem() * item.getAmount());
+                }
+                return new ResolvedItemWeight(true, modelData.weightPerItem(),
+                        modelData.boostPerItem() != 0f, modelData.boostPerItem());
             }
 
             String displayName = meta.getDisplayName();

--- a/src/main/java/ted_2001/WeightRPG/Utils/CalculateWeight.java
+++ b/src/main/java/ted_2001/WeightRPG/Utils/CalculateWeight.java
@@ -4,6 +4,7 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Sound;
 import org.bukkit.block.ShulkerBox;
@@ -17,7 +18,9 @@ import org.bukkit.persistence.PersistentDataType;
 import ted_2001.WeightRPG.Utils.WorldGuard.WorldGuardRegion;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 
 import static ted_2001.WeightRPG.Utils.JsonFile.boostItemsWeight;
@@ -36,6 +39,9 @@ public class CalculateWeight {
     private static final String DARK_RED_COLOR = "&4&l";
     private static final String[] COLOR_CODES = {"&a&l", "&2&l", "&e&l", "&6&l", "&c&l"};
 
+    private static final Map<ModelDataKey, Float> customModelDataWeights = new HashMap<>();
+    private static final Map<ModelDataKey, Float> customModelDataBoosts = new HashMap<>();
+
     private static NamespacedKey cachedWeightKey;
     private static NamespacedKey cachedBoostKey;
 
@@ -47,6 +53,78 @@ public class CalculateWeight {
         weightThresholdValues[0] = (float) getPlugin().getConfig().getDouble("weight-level-1.value");
         weightThresholdValues[1] = (float) getPlugin().getConfig().getDouble("weight-level-2.value");
         weightThresholdValues[2] = (float) getPlugin().getConfig().getDouble("weight-level-3.value");
+        refreshCustomModelDataMappings();
+    }
+
+    private static void refreshCustomModelDataMappings() {
+        customModelDataWeights.clear();
+        customModelDataBoosts.clear();
+        loadCustomModelDataMappings("custom-model-data-weight", customModelDataWeights);
+        loadCustomModelDataMappings("custom-model-data-boost", customModelDataBoosts);
+    }
+
+    private static void loadCustomModelDataMappings(String path, Map<ModelDataKey, Float> target) {
+        for (String entry : getPlugin().getConfig().getStringList(path)) {
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+
+            int equals = entry.lastIndexOf('=');
+            int separator = entry.lastIndexOf(';', equals - 1);
+            if (equals <= 0 || separator <= 0 || separator >= equals - 1 || equals == entry.length() - 1) {
+                getPlugin().getLogger().warning("Invalid " + path + " entry '" + entry
+                        + "'. Expected MATERIAL;MODEL_DATA=value");
+                continue;
+            }
+
+            String materialName = entry.substring(0, separator).trim().toUpperCase(Locale.ROOT);
+            String modelValue = entry.substring(separator + 1, equals).trim();
+            String configuredValue = entry.substring(equals + 1).trim();
+            Material material = Material.matchMaterial(materialName);
+            if (material == null) {
+                getPlugin().getLogger().warning("Invalid material in " + path + ": " + materialName);
+                continue;
+            }
+
+            try {
+                float modelData = Float.parseFloat(modelValue);
+                float value = Float.parseFloat(configuredValue);
+                if (!Float.isFinite(modelData) || !Float.isFinite(value)) {
+                    throw new NumberFormatException("non-finite value");
+                }
+                target.put(new ModelDataKey(material, modelData), value);
+            } catch (NumberFormatException exception) {
+                getPlugin().getLogger().warning("Invalid numeric value in " + path + " entry '" + entry + "'.");
+            }
+        }
+    }
+
+    public static ModelDataMatch resolveCustomModelData(ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return ModelDataMatch.NONE;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasCustomModelDataComponent()) {
+            return ModelDataMatch.NONE;
+        }
+
+        List<Float> floats = meta.getCustomModelDataComponent().getFloats();
+        if (floats.isEmpty()) {
+            return ModelDataMatch.NONE;
+        }
+
+        ModelDataKey key = new ModelDataKey(item.getType(), floats.getFirst());
+        Float weight = customModelDataWeights.get(key);
+        if (weight != null) {
+            return new ModelDataMatch(true, weight, 0f);
+        }
+
+        Float boost = customModelDataBoosts.get(key);
+        if (boost != null) {
+            return new ModelDataMatch(true, 0f, boost);
+        }
+        return ModelDataMatch.NONE;
     }
 
     public void calculateWeight(Player player) {
@@ -80,8 +158,6 @@ public class CalculateWeight {
         accumulateInventorySection(inventory.getStorageContents(), shulkerBoxesEnabled, player, total);
         accumulateInventorySection(inventory.getExtraContents(), shulkerBoxesEnabled, player, total);
         accumulateInventorySection(inventory.getArmorContents(), shulkerBoxesEnabled, player, total);
-
-        // Preserve the plugin's established inventory-slot/off-hand behavior exactly.
         accumulateItem(inventory.getItemInOffHand(), shulkerBoxesEnabled, player, total);
         return new CalculationResult(total.weight, total.boost);
     }
@@ -132,6 +208,11 @@ public class CalculateWeight {
         Float persistentBoost = pdc.get(boostKey(), PersistentDataType.FLOAT);
         if (persistentBoost != null) {
             return new ResolvedItem(0f, persistentBoost);
+        }
+
+        ModelDataMatch modelData = resolveCustomModelData(item);
+        if (modelData.matched()) {
+            return new ResolvedItem(modelData.weightPerItem(), modelData.boostPerItem());
         }
 
         String displayName = itemMeta.getDisplayName();
@@ -419,6 +500,11 @@ public class CalculateWeight {
         }
     }
 
+    public record ModelDataMatch(boolean matched, float weightPerItem, float boostPerItem) {
+        private static final ModelDataMatch NONE = new ModelDataMatch(false, 0f, 0f);
+    }
+
+    private record ModelDataKey(Material material, float modelData) { }
     private record ResolvedItem(float weightPerItem, float boostPerItem) { }
     private record CalculationResult(float weight, float boost) { }
     private record Thresholds(float level1, float level2, float level3) { }

--- a/src/main/java/ted_2001/WeightRPG/Utils/PlaceholderAPI/WeightExpansion.java
+++ b/src/main/java/ted_2001/WeightRPG/Utils/PlaceholderAPI/WeightExpansion.java
@@ -123,9 +123,16 @@ public class WeightExpansion extends PlaceholderExpansion {
                 return String.valueOf(persistentWeight * item.getAmount());
             }
 
-            // Persistent boost items, like configured boost items, have no own weight.
             if (pdc.has(boostKey, PersistentDataType.FLOAT)) {
                 return "0";
+            }
+
+            CalculateWeight.ModelDataMatch modelData = CalculateWeight.resolveCustomModelData(item);
+            if (modelData.matched()) {
+                if (modelData.boostPerItem() != 0f) {
+                    return "0";
+                }
+                return String.valueOf(modelData.weightPerItem() * item.getAmount());
             }
 
             String displayName = itemMeta.getDisplayName();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -108,6 +108,20 @@ boost-items:
   - "&aSuper Backpack=50"
   - "&#1cebee&lEnhanced Bag=100"
 
+# Custom Model Data support.
+# Format: "MATERIAL;MODEL_DATA=weight"
+# The first float in Minecraft's modern CustomModelDataComponent is used as the model identifier.
+# Old integer Custom Model Data values are represented by Minecraft/Spigot as a single float,
+# so an old model id such as 1001 can be configured simply as 1001 here.
+# These rules are read-only: Weight-RPG does NOT write or change Custom Model Data on the item.
+custom-model-data-weight:
+  # - "DIAMOND_SWORD;1001=25"
+
+# Custom Model Data items that increase carrying capacity and have zero own weight.
+# Boost is multiplied by stack size: two items with a boost of 100 give +200 capacity.
+custom-model-data-boost:
+  # - "PAPER;5001=100"
+
 plugin-prefix: "&7[&eWeight-RPG&7]&f: "
 
 # Add a line in the lore of each item showing its unit weight. (default is false)


### PR DESCRIPTION
## What changed
- add read-only Custom Model Data weight rules
- add read-only Custom Model Data boost/capacity rules
- use the first float in the modern `CustomModelDataComponent` as the model identifier
- preserve compatibility with legacy integer Custom Model Data IDs, which Spigot exposes as a single float in the component
- cache configured model rules instead of scanning config lists for every inventory item
- apply model rules consistently in full inventory calculations, shulker contents, pickup/drop/place event paths, lore updates, and PlaceholderAPI item placeholders
- keep existing precedence: Weight-RPG PDC weight/boost -> Custom Model Data -> custom display-name weight/boost -> global material weight
- keep boost stacking behavior: configured boost is multiplied by item stack size

## Configuration
```yaml
custom-model-data-weight:
  # - "DIAMOND_SWORD;1001=25"

custom-model-data-boost:
  # - "PAPER;5001=100"
```

Format: `MATERIAL;MODEL_DATA=value`.

Weight-RPG only reads Custom Model Data. It does not write, replace, or remove the item's model component, so this feature does not leave new Weight-RPG metadata behind on items.

## Scope
This is intentionally a separate stacked feature PR based on `agent/spigot-26.2-modernization` / PR #16. It does not add lore-based weight parsing and does not modify the three vanilla JSON weight files.

## Validation
- Java 25 / Spigot 26.1 matrix build: success
- Java 25 / Spigot 26.2 matrix build: success
